### PR TITLE
Allow mapping array values, not just references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,40 +8,37 @@
 /// assert_eq!([2, 3, 4], x.map(|v| v + 1));
 /// ```
 pub trait ArrayMap<X, Y, T> {
-    fn map<F: Fn(&X) -> Y>(&self, f: F) -> T;
-}
-
-macro_rules! map_inner {
-    {$f:ident, $s:expr, []; $n:expr, $($ns:expr),*,} => {
-        map_inner!($f, $s, [$f(&$s[$n])]; $($ns),*,)
-    };
-    {$f:ident, $s:expr, [$($t:tt)*]; $n:expr, $($ns:expr),*,} => {
-        map_inner!($f, $s, [$f(&$s[$n]), $($t)*]; $($ns),*,)
-    };
-    {$f:ident, $s:expr, [$($t:tt)*]; $n:expr, } => {
-        map_inner!($f, $s, [$f(&$s[$n]), $($t)*])
-    };
-    {$f:ident, $s:expr, $t:expr} => { $t };
+    fn map<F: Fn(X) -> Y>(self, f: F) -> T;
 }
 
 macro_rules! map_impl {
-    {$n:expr, $($ns:expr),*} => {
+    {$n:tt, $v:ident, $($ns:tt, $vs:ident),*} => {
         impl<U, V> ArrayMap<U, V, [V; $n]> for [U; $n] {
-            fn map<F: Fn(&U) -> V>(&self, f: F) -> [V; $n] {
-                map_inner!(f, self, []; $($ns),*,)
+            fn map<F: Fn(U) -> V>(self, f: F) -> [V; $n] {
+                (|[$($vs),*]: [U; $n]| [$(f($vs)),*])(self)
             }
         }
-        map_impl!{$($ns),*}
+        impl<'a, U, V> ArrayMap<&'a U, V, [V; $n]> for &'a [U; $n] {
+            fn map<F: Fn(&'a U) -> V>(self, f: F) -> [V; $n] {
+                (|&[$(ref $vs),*]: &'a [U; $n]| [$(f($vs)),*])(self)
+            }
+        }
+        map_impl!{$($ns, $vs),*}
     };
-    {$n:expr} => { /* nothing to do here */ }
+    {$n:tt, $v:ident} => { /* nothing to do here */ }
 }
 
 impl<U, V> ArrayMap<U, V, [V; 0]> for [U; 0] {
-    fn map<F: Fn(&U) -> V>(&self, _: F) -> [V; 0] { [] }
+    fn map<F: Fn(U) -> V>(self, _: F) -> [V; 0] { [] }
+}
+impl<'a, U, V> ArrayMap<&'a U, V, [V; 0]> for &'a [U; 0] {
+    fn map<F: Fn(&'a U) -> V>(self, _: F) -> [V; 0] { [] }
 }
 
-map_impl!{32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
-          15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+map_impl!{32, x32, 31, x31, 30, x30, 29, x29, 28, x28, 27, x27, 26, x26, 25, x25,
+          24, x24, 23, x23, 22, x22, 21, x21, 20, x20, 19, x19, 18, x18, 17, x17,
+          16, x16, 15, x15, 14, x14, 13, x13, 12, x12, 11, x11, 10, x10, 9, x9,
+          8, x8, 7, x7, 6, x6, 5, x5, 4, x4, 3, x3, 2, x2, 1, x1, 0, x0}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This enables operations like `[vec![1, 2, 3], vec![4]].map(|v| v.into_boxed_slice())`, consuming the old array without copying.

Note: if `a` is an array value instead of a reference, you may now need to write `(&a).map()` to get the previous behavior of `a.map()`.