### PR TITLE
Mark the crate as no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// map a function over an array
 ///
 /// Examples:


### PR DESCRIPTION
The crate doesn't use `std`. Marking the crate as `no_std` allows it to be used on targets that don't have `std`.